### PR TITLE
[eclipse/xtext#1221] Assure working directory exists before cleanup

### DIFF
--- a/eclipse/promoter.ant
+++ b/eclipse/promoter.ant
@@ -178,7 +178,9 @@
 
 	<target name="publish" unless="alreadyPromoted">
 
-		<echo>Remove old  nightly builds</echo>
+		<echo>Remove old nightly builds</echo>
+		<!-- make sure that working dir exists -->
+		<mkdir dir="${downloads.area}/downloads/drops/${version}" />
 		<antcall target="-cleanup.nightly">
 			<param name="working_dir" value="${downloads.area}/downloads/drops/${version}/" />
 		</antcall>


### PR DESCRIPTION
The script fails when the parent directory for nightlies does not exist
yet. This happens when the version changes. Calling a mkdir to assure
that the working directory does exist before trying to cleanup its
contents.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>