### PR TITLE
[eclipse/xtext#1348] Use JENKINS_URL property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,17 @@
 apply plugin: 'io.typefox.osspub'
 apply from: 'artifacts.gradle'
 
+if (!hasProperty('JENKINS_URL')) {
+  ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+}
+
 def mavenSource = findProperty('mavenSource')
 if (mavenSource == null || mavenSource == 'jenkins') {
 	def jenkinsRepo = { jobName ->
-		"http://services.typefox.io/open-source/jenkins/job/${jobName}/lastStableBuild/artifact/build/maven-repository/"
+		"$JENKINS_URL/job/${jobName}/lastStableBuild/artifact/build/maven-repository/"
 	}
 	def jenkinsPipelineRepo = { jobName ->
-		"http://services.typefox.io/open-source/jenkins/job/${jobName}/job/${osspub.branch}/lastStableBuild/artifact/build/maven-repository/"
+		"$JENKINS_URL/job/${jobName}/job/${osspub.branch}/lastStableBuild/artifact/build/maven-repository/"
 	}
 	repositories {
 		maven { url jenkinsPipelineRepo('lsp4j') }
@@ -20,10 +24,10 @@ if (mavenSource == null || mavenSource == 'jenkins') {
 		maven { url jenkinsPipelineRepo('xtext-core') }
 		maven { url jenkinsPipelineRepo('xtext-extras') }
 		maven { url jenkinsPipelineRepo('xtext-web') }
-		maven { url "http://services.typefox.io/open-source/jenkins/job/xtext-maven/job/${osspub.branch}/lastSuccessfulBuild/artifact/build/maven-repository/" }
-		maven { url jenkinsPipelineRepo('xtext-xtend') }
+		maven { url jenkinsPipelineRepo('xtext-maven') }
+		maven { url "$JENKINS_URL/job/xtext-xtend/job/${osspub.branch}/lastSuccessfulBuild/artifact/build/maven-repository/" }
 		maven { url jenkinsPipelineRepo('xtext-jflex') }
-		maven { url "http://services.typefox.io/open-source/jenkins/job/yang-lsp/job/${osspub.branch}/lastStableBuild/artifact/yang-lsp/build/maven-repository/" }
+		maven { url "$JENKINS_URL/job/yang-lsp/job/${osspub.branch}/lastStableBuild/artifact/yang-lsp/build/maven-repository/" }
 		maven { url "https://jenkins.eclipse.org/sprotty/job/sprotty-server/job/${osspub.branch}/lastStableBuild/artifact/build/maven-repository/" }
 	}
 } else if (mavenSource == 'hudsonSnapshot') {
@@ -55,7 +59,7 @@ osspub {
 	p2Repository {
 		name 'Xtext'
 		group 'modeling.tmf.xtext'
-		url "http://services.typefox.io/open-source/jenkins/job/xtext-umbrella/job/${osspub.branch}/lastStableBuild/artifact/build/org.eclipse.xtext.sdk.p2-repository-${osspub.version}.zip"
+		url "$JENKINS_URL/job/xtext-umbrella/job/${osspub.branch}/lastStableBuild/artifact/build/org.eclipse.xtext.sdk.p2-repository-${osspub.version}.zip"
 		namespace 'org.eclipse.xtext'
 		namespace 'org.eclipse.xtend'
 		namespace 'org.eclipse.lsp4j'
@@ -67,7 +71,7 @@ osspub {
 	p2Repository {
 		name 'Lsp4j'
 		group 'technology.lsp4j'
-		url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/${osspub.branch}/lastStableBuild/artifact/build/lsp4j.p2-repository-${osspub.version}.zip"
+		url "$JENKINS_URL/job/lsp4j/job/${osspub.branch}/lastStableBuild/artifact/build/lsp4j.p2-repository-${osspub.version}.zip"
 		deployPath 'lsp4j'
 		namespace 'org.eclipse.lsp4j'
 		referenceFeature 'org.eclipse.lsp4j.sdk'


### PR DESCRIPTION
This will evaluate the JENKINS_URL property when present (defaults to TF Jenkins URL) for Xtext repositories to use the local Jenkins instance (like JIPP, CBI)